### PR TITLE
package.json needs bin declaration

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,9 @@
     "type": "git",
     "url": "http://github.com/coderaiser/minify.git"
   },
+  "bin": {
+    "minify": "./bin/minify"
+  },
   "scripts": {
     "test": "node test/test.js"
   },


### PR DESCRIPTION
Necessary to make the bin executable when installing and available in your path when installing globally.
