### PR TITLE
Remove unused function 'getName'

### DIFF
--- a/lib/minify.js
+++ b/lib/minify.js
@@ -35,17 +35,8 @@ async function minify(name, userOptions) {
     return await optimize(name, userOptions);
 }
 
-function getName(file) {
-    const notObj = typeof file !== 'object';
-    
-    if (notObj)
-        return file;
-    
-    return Object.keys(file)[0];
-}
-
 /**
- * function minificate js,css and html files
+ * function minificate js, css and html files
  *
  * @param {string} file - js, css or html file path
  * @param {object} userOptions - object with optional `html`, `css, `js`, and `img` keys, which each can contain options to be combined with defaults and passed to the respective minifier
@@ -53,11 +44,9 @@ function getName(file) {
 async function optimize(file, userOptions) {
     check(file);
     
-    const name = getName(file);
+    log('reading file ' + path.basename(file));
     
-    log('reading file ' + path.basename(name));
-    
-    const data = await readFile(name, 'utf8');
+    const data = await readFile(file, 'utf8');
     return await onDataRead(file, data, userOptions);
 }
 


### PR DESCRIPTION
Hi! I wanted to help improve code coverage (#55), and the first thing I stumbled upon seems to be code that isn't used anymore. I believe this code can be removed.

`getName` checks to see if the `optimize` function has been passed an object instead of a string, in which case it tries to turn the object into a string. But it doesn't seem like it is possible to pass it an object. If I try to pass an object to `minify`, it will throw an error, and the documentation you wrote for `optimize` specifically calls for a string - no mention of an object.
In older versions of minify, it seems like some of these functions could be accessed much more directly, so I would guess that something was passing weird objects directly to `optimize`, and `getName` was built to accept those edge cases. That doesn't seem to be necessary anymore :)

I am also working on adding test coverage for the remaining parts of your code. Thank you for this awesome package!