### PR TITLE
feature: Add support for cli options to control the minifiers

### DIFF
--- a/bin/minify.js
+++ b/bin/minify.js
@@ -4,7 +4,7 @@
 
 const Pack = require('../package');
 const Version = Pack.version;
-const processOptions = require("../lib/processOptions");
+const processOptions = require('../lib/processOptions');
 
 const log = function(...args) {
     console.log(...args);
@@ -55,7 +55,7 @@ function minify() {
         return log('v' + Version);
     
     const [files, options] = processOptions(cliParameters);
-
+    
     uglifyFiles(files, options);
 }
 
@@ -102,10 +102,10 @@ function help() {
 Examples:
   minify -h
     Print this message.
-
+  
   cat hello.js > minify --js > hello.min.js
     Minify js as part of a pipeline of stream processors.
-
+  
   minify hello.html --html-options="{\\"removeOptionalTags\\": false}" > hello.min.html
     Minify an html file, writing it to a new file, without removing optional tags.
 

--- a/bin/minify.js
+++ b/bin/minify.js
@@ -4,6 +4,7 @@
 
 const Pack = require('../package');
 const Version = Pack.version;
+const processOptions = require("../lib/processOptions");
 
 const log = function(...args) {
     console.log(...args);
@@ -92,51 +93,27 @@ function logAll(array) {
 function help() {
     const bin = require('../help');
     
-    console.log('Usage:');
-    console.log('  minify [options]');
-    console.log('    This will read from stdin and output to stdout.');
-    console.log('  minify filePath [options]');
-    console.log('    This will read from a file and output to stdout.');
-    console.log('');
-    console.log('Examples:');
-    console.log('  minify -h');
-    console.log('    Print this message.');
-    console.log('');
-    console.log('  cat hello.js > minify --js > hello.min.js');
-    console.log('    Minify js as part of a pipeline of stream processors.');
-    console.log('');
-    console.log('  minify hello.html --htmlOptions="{\\"removeOptionalTags\\": false}" > hello.min.html');
-    console.log('    Minify an html file, writing it to a new file, without removing optional tags.');
-    console.log('');
-    console.log('Options:');
+    const helpString = `Usage:
+  minify [options]
+    This will read from stdin and output to stdout.
+  minify filePath [options]
+    This will read from a file and output to stdout.
+
+Examples:
+  minify -h
+    Print this message.
+
+  cat hello.js > minify --js > hello.min.js
+    Minify js as part of a pipeline of stream processors.
+
+  minify hello.html --html-options="{\\"removeOptionalTags\\": false}" > hello.min.html
+    Minify an html file, writing it to a new file, without removing optional tags.
+
+Options:`;
+    
+    console.log(helpString);
     
     for (const name of Object.keys(bin)) {
         console.log('  %s %s', name, bin[name]);
     }
-}
-
-function processOptions(cliOptions) {
-    const options = {};
-    const files = [];
-
-    cliOptions.forEach((option) => {
-        const [key, val] = option.split('=');
-        switch (key) {
-            case '--htmlOptions':
-                options['html'] = JSON.parse(val);
-                break;
-            case '--imgOptions':
-                options['img'] = JSON.parse(val);
-                break;
-            case '--jsOptions':
-                options['js'] = JSON.parse(val);
-                break;
-            case '--cssOptions':
-                options['css'] = JSON.parse(val);
-                break;
-            default:
-                files.push(option)
-        }
-    })
-    return [files, options];
 }

--- a/help.json
+++ b/help.json
@@ -3,5 +3,9 @@
     "-v, --version              ": "display version and exit",
     "--js                       ": "minify javascript",
     "--css                      ": "minify css",
-    "--html                     ": "minify html"
+    "--html                     ": "minify html",
+    "--htmlOptions=<json>       ": "while minifying from a file, specify a set of options to be passed to the html minifyier",
+    "--imgOptions=<json>        ": "while minifying from a file, specify a set of options to be passed to the img minifyier",
+    "--jsOptions=<json>         ": "while minifying from a file, specify a set of options to be passed to the js minifyier",
+    "--cssOptions=<json>        ": "while minifying from a file, specify a set of options to be passed to the css minifyier"
 }

--- a/help.json
+++ b/help.json
@@ -4,8 +4,8 @@
     "--js                       ": "minify javascript",
     "--css                      ": "minify css",
     "--html                     ": "minify html",
-    "--htmlOptions=<json>       ": "while minifying from a file, specify a set of options to be passed to the html minifyier",
-    "--imgOptions=<json>        ": "while minifying from a file, specify a set of options to be passed to the img minifyier",
-    "--jsOptions=<json>         ": "while minifying from a file, specify a set of options to be passed to the js minifyier",
-    "--cssOptions=<json>        ": "while minifying from a file, specify a set of options to be passed to the css minifyier"
+    "--html-options=<json>      ": "while minifying from a file, specify a set of options to be passed to the html minifyier",
+    "--img-options=<json>       ": "while minifying from a file, specify a set of options to be passed to the img minifyier",
+    "--js-options=<json>        ": "while minifying from a file, specify a set of options to be passed to the js minifyier",
+    "--css-options=<json>       ": "while minifying from a file, specify a set of options to be passed to the css minifyier"
 }

--- a/lib/processOptions.js
+++ b/lib/processOptions.js
@@ -1,26 +1,28 @@
+'use strict';
+
 function processOptions(cliOptions) {
     const options = {};
     const files = [];
-
-    cliOptions.forEach((option) => {
+    
+    for (const option of cliOptions) {
         const [key, val] = option.split('=');
-        switch (key) {
-            case '--html-options':
-                options['html'] = JSON.parse(val);
-                break;
-            case '--img-options':
-                options['img'] = JSON.parse(val);
-                break;
-            case '--js-options':
-                options['js'] = JSON.parse(val);
-                break;
-            case '--css-options':
-                options['css'] = JSON.parse(val);
-                break;
-            default:
-                files.push(option)
+        switch(key) {
+        case '--html-options':
+            options['html'] = JSON.parse(val);
+            break;
+        case '--img-options':
+            options['img'] = JSON.parse(val);
+            break;
+        case '--js-options':
+            options['js'] = JSON.parse(val);
+            break;
+        case '--css-options':
+            options['css'] = JSON.parse(val);
+            break;
+        default:
+            files.push(option);
         }
-    })
+    }
     return [files, options];
 }
 

--- a/lib/processOptions.js
+++ b/lib/processOptions.js
@@ -1,0 +1,27 @@
+function processOptions(cliOptions) {
+    const options = {};
+    const files = [];
+
+    cliOptions.forEach((option) => {
+        const [key, val] = option.split('=');
+        switch (key) {
+            case '--html-options':
+                options['html'] = JSON.parse(val);
+                break;
+            case '--img-options':
+                options['img'] = JSON.parse(val);
+                break;
+            case '--js-options':
+                options['js'] = JSON.parse(val);
+                break;
+            case '--css-options':
+                options['css'] = JSON.parse(val);
+                break;
+            default:
+                files.push(option)
+        }
+    })
+    return [files, options];
+}
+
+module.exports = processOptions;

--- a/test/processOptions.js
+++ b/test/processOptions.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const processOptions = require('../lib/processOptions');
 const test = require('supertape');
 
@@ -5,33 +7,33 @@ test('processOptions', (t) => {
     const testOptions = [
         'hello.js',
         'src/public/index.html',
-        '--html-options={\"htmlOptionMock\": \"htmlValueMock\"}',
-        '--js-options={\"jsOptionMock\": \"jsValueMock\"}',
-        '--css-options={\"cssOptionMock\": \"cssValueMock\"}',
-        '--img-options={\"imgOptionMock\": \"imgValueMock\"}',
-    ]
+        '--html-options={"htmlOptionMock": "htmlValueMock"}',
+        '--js-options={"jsOptionMock": "jsValueMock"}',
+        '--css-options={"cssOptionMock": "cssValueMock"}',
+        '--img-options={"imgOptionMock": "imgValueMock"}',
+    ];
     const [files, options] = processOptions(testOptions);
     t.deepEqual(files, ['hello.js',
         'src/public/index.html']);
-    t.deepEqual(options,  {
-        "css":  {
-            "cssOptionMock": "cssValueMock",
+    t.deepEqual(options, {
+        css: {
+            cssOptionMock: 'cssValueMock',
         },
-        "html":  {
-            "htmlOptionMock": "htmlValueMock",
+        html: {
+            htmlOptionMock: 'htmlValueMock',
         },
-        "img":  {
-            "imgOptionMock": "imgValueMock",
+        img: {
+            imgOptionMock: 'imgValueMock',
         },
-        "js":  {
-            "jsOptionMock": "jsValueMock",
+        js: {
+            jsOptionMock: 'jsValueMock',
         },
-    })
-})
+    });
+});
 
 test('processOptions doesnt fail with empty input', (t) => {
-    const testOptions = []
+    const testOptions = [];
     const [files, options] = processOptions(testOptions);
     t.deepEqual(files, []);
-    t.deepEqual(options, {})
-})
+    t.deepEqual(options, {});
+});

--- a/test/processOptions.js
+++ b/test/processOptions.js
@@ -15,16 +15,16 @@ test('processOptions', (t) => {
         'src/public/index.html']);
     t.deepEqual(options,  {
         "css":  {
-            "cssOptionMock": "cssValueMak",
+            "cssOptionMock": "cssValueMock",
         },
         "html":  {
-            "htmlOptionMock": "htmlValueMak",
+            "htmlOptionMock": "htmlValueMock",
         },
         "img":  {
-            "imgOptionMock": "imgValueMak",
+            "imgOptionMock": "imgValueMock",
         },
         "js":  {
-            "jsOptionMock": "jsValueMak",
+            "jsOptionMock": "jsValueMock",
         },
     })
 })

--- a/test/processOptions.js
+++ b/test/processOptions.js
@@ -5,10 +5,10 @@ test('processOptions', (t) => {
     const testOptions = [
         'hello.js',
         'src/public/index.html',
-        '--html-options={\"htmlOptionMock\": \"htmlValueMak\"}',
-        '--js-options={\"jsOptionMock\": \"jsValueMak\"}',
-        '--css-options={\"cssOptionMock\": \"cssValueMak\"}',
-        '--img-options={\"imgOptionMock\": \"imgValueMak\"}',
+        '--html-options={\"htmlOptionMock\": \"htmlValueMock\"}',
+        '--js-options={\"jsOptionMock\": \"jsValueMock\"}',
+        '--css-options={\"cssOptionMock\": \"cssValueMock\"}',
+        '--img-options={\"imgOptionMock\": \"imgValueMock\"}',
     ]
     const [files, options] = processOptions(testOptions);
     t.deepEqual(files, ['hello.js',

--- a/test/processOptions.js
+++ b/test/processOptions.js
@@ -1,0 +1,37 @@
+const processOptions = require('../lib/processOptions');
+const test = require('supertape');
+
+test('processOptions', (t) => {
+    const testOptions = [
+        'hello.js',
+        'src/public/index.html',
+        '--html-options={\"htmlOptionMock\": \"htmlValueMak\"}',
+        '--js-options={\"jsOptionMock\": \"jsValueMak\"}',
+        '--css-options={\"cssOptionMock\": \"cssValueMak\"}',
+        '--img-options={\"imgOptionMock\": \"imgValueMak\"}',
+    ]
+    const [files, options] = processOptions(testOptions);
+    t.deepEqual(files, ['hello.js',
+        'src/public/index.html']);
+    t.deepEqual(options,  {
+        "css":  {
+            "cssOptionMock": "cssValueMak",
+        },
+        "html":  {
+            "htmlOptionMock": "htmlValueMak",
+        },
+        "img":  {
+            "imgOptionMock": "imgValueMak",
+        },
+        "js":  {
+            "jsOptionMock": "jsValueMak",
+        },
+    })
+})
+
+test('processOptions doesnt fail with empty input', (t) => {
+    const testOptions = []
+    const [files, options] = processOptions(testOptions);
+    t.deepEqual(files, []);
+    t.deepEqual(options, {})
+})


### PR DESCRIPTION
This closes #62 
by allowing the user to specify a set of options to be passed to the minifier
E.G. `minify hello.html --html-options="{\"removeOptionalTags\": false}" > hello.min.html`