### PR TITLE
feature: Add support for .minify.json config file

### DIFF
--- a/bin/minify.js
+++ b/bin/minify.js
@@ -3,11 +3,8 @@
 'use strict';
 
 const Pack = require('../package');
-const fs = require('fs');
+const {findOptionsFromFile} = require('../lib/options');
 const Version = Pack.version;
-
-// currently only look in the directory from which the command was run.
-const configFilePath = process.cwd() + '/.minify.json';
 
 const log = function(...args) {
     console.log(...args);
@@ -35,62 +32,57 @@ function readStd(callback) {
     let chunks = '';
     const read = () => {
         const chunk = stdin.read();
-
+        
         if (chunk)
             return chunks += chunk;
-
+        
         stdin.removeListener('readable', read);
         callback(chunks);
     };
-
+    
     stdin.setEncoding('utf8');
     stdin.addListener('readable', read);
 }
 
-function minify() {
+async function minify() {
     if (!In || /^(-h|--help)$/.test(In))
         return help();
-
+    
     if (/^--(js|css|html)$/.test(In))
         return readStd(processStream);
-
+    
     if (/^(-v|--version)$/.test(In))
         return log('v' + Version);
-
-    let options = {};
-    if (fs.existsSync(configFilePath)) {
-        try {
-            options = JSON.parse(fs.readFileSync(configFilePath));
-        } catch (err) {
-            log.error(`Config file at ${configFilePath} could not be parsed with error`);
-            return log.error(err.message);
-        }
-    }
-
+    
+    const {options, error: optionsError} = await findOptionsFromFile();
+    
+    if (optionsError)
+        return log.error(optionsError.message);
+    
     uglifyFiles(files, options);
 }
 
 async function processStream(chunks) {
     const minify = require('..');
     const tryToCatch = require('try-to-catch');
-
+    
     if (!chunks || !In)
         return;
-
+    
     const name = In.replace('--', '');
-
+    
     const [e, data] = await tryToCatch(minify[name], chunks);
-
+    
     if (e)
         return log.error(e);
-
+    
     log(data);
 }
 
 function uglifyFiles(files, options) {
     const minify = require('..');
     const minifiers = files.map((file) => minify(file, options));
-
+    
     Promise.all(minifiers)
         .then(logAll)
         .catch(log.error);
@@ -104,10 +96,10 @@ function logAll(array) {
 function help() {
     const bin = require('../help');
     const usage = 'Usage: minify [options]';
-
+    
     console.log(usage);
     console.log('Options:');
-
+    
     for (const name of Object.keys(bin)) {
         console.log('  %s %s', name, bin[name]);
     }

--- a/lib/options.js
+++ b/lib/options.js
@@ -1,0 +1,24 @@
+'use strict';
+
+const {readFileSync} = require('fs');
+const findUp = require('find-up');
+
+async function findOptionsFromFile({readFile = readFileSync, findOptionsFile = findUp} = {}) {
+    const filePath = await findOptionsFile('.minify.json');
+    
+    if (filePath) {
+        try {
+            return {options: JSON.parse(readFile(filePath))};
+        } catch(err) {
+            return {
+                error: new Error(`Options file at ${filePath} could not be parsed with error\n${err.message}`),
+            };
+        }
+    }
+    
+    return {options: {}};
+}
+
+module.exports = {
+    findOptionsFromFile,
+};

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "clean-css": "^5.0.1",
     "css-b64-images": "~0.2.5",
     "debug": "^4.1.0",
+    "find-up": "^5.0.0",
     "html-minifier-terser": "^5.1.1",
     "terser": "^5.3.2",
     "try-to-catch": "^3.0.0"

--- a/test/libOptions.js
+++ b/test/libOptions.js
@@ -1,0 +1,48 @@
+'use strict';
+
+const {stub, test} = require('supertape');
+const {findOptionsFromFile} = require('../lib/options');
+
+const mockOptions = {
+    mockOption: 'mockValue',
+};
+
+test('findOptionsFromFile: return the options from the found file', async (t) => {
+    const findOptionsFile = stub().resolves('/filePathMock');
+    const readFile = stub().returns(JSON.stringify(mockOptions));
+    
+    const {options, error} = await findOptionsFromFile({readFile, findOptionsFile});
+    t.deepEqual(options, mockOptions);
+    t.deepEqual(error, undefined);
+    t.deepEqual(findOptionsFile.callCount, 1);
+    t.deepEqual(findOptionsFile.args[0], ['.minify.json']);
+    t.deepEqual(readFile.callCount, 1);
+    t.deepEqual(readFile.args[0], ['/filePathMock']);
+});
+
+test('findOptionsFromFile: return options = {} if the options file is not found', async (t) => {
+    const findOptionsFile = stub().resolves(undefined);
+    const readFile = stub().returns(JSON.stringify(mockOptions));
+    
+    const {options, error} = await findOptionsFromFile({readFile, findOptionsFile});
+    t.deepEqual(options, {});
+    t.deepEqual(error, undefined);
+    t.deepEqual(findOptionsFile.callCount, 1);
+    t.deepEqual(findOptionsFile.args[0], ['.minify.json']);
+    t.deepEqual(readFile.callCount, 0);
+});
+
+test('findOptionsFromFile: return a meaningfull error if the options file cannot be parsed', async (t) => {
+    const findOptionsFile = stub().resolves('/filePathMock');
+    const readFile = stub().returns('} Invalid JSON');
+    
+    const {options, error} = await findOptionsFromFile({readFile, findOptionsFile});
+    
+    t.deepEqual(options, undefined);
+    t.deepEqual(error, new Error(`Options file at /filePathMock could not be parsed with error\nUnexpected token } in JSON at position 0`));
+    t.deepEqual(findOptionsFile.callCount, 1);
+    t.deepEqual(findOptionsFile.args[0], ['.minify.json']);
+    t.deepEqual(readFile.callCount, 1);
+    t.deepEqual(readFile.args[0], ['/filePathMock']);
+});
+


### PR DESCRIPTION
This closes #69 by allowing the user to provide a file in the current working directory under `.minify.json`

If the file exists, but cannot be parsed, minify will exist with an error such as the one below (full file path redacted)
```
Config file at /Users/[Redacted]/.minify.json could not be parsed with error
Unexpected token } in JSON at position 49
```