### PR TITLE
chore(libOptions) rename file to mimic code path

### DIFF
--- a/.madrun.mjs
+++ b/.madrun.mjs
@@ -1,7 +1,7 @@
 import {run} from 'madrun';
 
 export default {
-    'test': () => 'tape test/*.js',
+    'test': () => 'tape test/*.js test/lib/*.js',
     'coverage': () => 'c8 npm test',
     'report': () => 'c8 report --reporter=lcov',
     'fix:lint': () => run('lint', '--fix'),

--- a/lib/options.js
+++ b/lib/options.js
@@ -11,7 +11,7 @@ async function findOptionsFromFile({readFile = readFileSync, findOptionsFile = f
             return {options: JSON.parse(readFile(filePath))};
         } catch(err) {
             return {
-                error: new Error(`Options file at ${filePath} could not be parsed with error\n${err.message}`),
+                error: Error(`Options file at ${filePath} could not be parsed with error\n${err.message}`),
             };
         }
     }

--- a/test/lib/options.js
+++ b/test/lib/options.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const {stub, test} = require('supertape');
-const {findOptionsFromFile} = require('../lib/options');
+const {findOptionsFromFile} = require('../../lib/options');
 
 const mockOptions = {
     mockOption: 'mockValue',
@@ -39,7 +39,7 @@ test('findOptionsFromFile: return a meaningfull error if the options file cannot
     const {options, error} = await findOptionsFromFile({readFile, findOptionsFile});
     
     t.deepEqual(options, undefined);
-    t.deepEqual(error, new Error(`Options file at /filePathMock could not be parsed with error\nUnexpected token } in JSON at position 0`));
+    t.deepEqual(error, Error(`Options file at /filePathMock could not be parsed with error\nUnexpected token } in JSON at position 0`));
     t.deepEqual(findOptionsFile.callCount, 1);
     t.deepEqual(findOptionsFile.args[0], ['.minify.json']);
     t.deepEqual(readFile.callCount, 1);


### PR DESCRIPTION
Closes #75

I know the issue only asked for renamed file, but I have also moved it to the lib folder to mimic the code path?

Let me know if this is not something you wanted.