### PR TITLE
fixed path to lib/minify.js in bin/minify.js

### DIFF
--- a/bin/minify.js
+++ b/bin/minify.js
@@ -66,7 +66,7 @@ async function minify() {
 }
 
 async function processStream(chunks) {
-    const {minify} = await import('../lib/minify');
+    const {minify} = await import('../lib/minify.js');
     
     if (!chunks || !In)
         return;


### PR DESCRIPTION
I install minify on almost every one of my projects (thank you to all who contribute to this amazing tool), and recently (in the past week or so), every time I install minify, I need to go and edit this manually otherwise it doesn't work. Someone else raised an issue (https://github.com/coderaiser/minify/issues/86) about this so I didn't bother to create another one.

For some reason, on line 85 we see:
```javascript
const {minify} = await import('../lib/minify.js');
```

but just a few lines back on 69 we see:
```javascript
const {minify} = await import('../lib/minify'); // note missing ".js"
```

So, I'm not sure who did that or when, but this fixes it. Cheers!