### PR TITLE
feature(minify) force minify unsupported extensions

### DIFF
--- a/lib/minify.js
+++ b/lib/minify.js
@@ -36,14 +36,14 @@ export async function minify(name, userOptions) {
     
     check(name);
     
-    const ext = path.extname(name).slice(1);
-    const is = EXT.includes(ext);
+    const type = process.argv.find(arg => EXT.includes(arg.slice(2)))?.slice(2) ?? path.extname(name).slice(1);
+    const is = EXT.includes(type);
     
     if (!is)
-        throw Error(`File type "${ext}" not supported.`);
+        throw Error(`File type "${type}" not supported.`);
     
     log('optimizing ' + path.basename(name));
-    return await optimize(name, userOptions);
+    return await optimize(name, userOptions, type);
 }
 
 /**
@@ -51,14 +51,15 @@ export async function minify(name, userOptions) {
  *
  * @param {string} file - js, css or html file path
  * @param {object} userOptions - object with optional `html`, `css, `js`, and `img` keys, which each can contain options to be combined with defaults and passed to the respective minifier
+ * @param {string} type - file type based on extension or user-supplied argument (--js, --css, --html)
  */
-async function optimize(file, userOptions) {
+async function optimize(file, userOptions, type) {
     check(file);
     
     log('reading file ' + path.basename(file));
     
     const data = await readFile(file, 'utf8');
-    return await onDataRead(file, data, userOptions);
+    return await onDataRead(file, data, userOptions, type);
 }
 
 /**
@@ -66,17 +67,16 @@ async function optimize(file, userOptions) {
  * @param {string} filename
  * @param {string} data - the contents of the file
  * @param {object} userOptions - object with optional `html`, `css, `js`, and `img` keys, which each can contain options to be combined with defaults and passed to the respective minifier
+ * @param {string} type - file type based on extension or user-supplied argument (--js, --css, --html)
 */
-async function onDataRead(filename, data, userOptions) {
+async function onDataRead(filename, data, userOptions, type) {
     log('file ' + path.basename(filename) + ' read');
     
-    const ext = path.extname(filename).replace(/^\./, '');
-    
-    const optimizedData = await minifiers[ext](data, userOptions);
+    const optimizedData = await minifiers[type](data, userOptions);
     
     let b64Optimize;
     
-    if (ext === 'css')
+    if (type === 'css')
         [, b64Optimize] = await tryToCatch(minifiers.img, filename, optimizedData, userOptions);
     
     return b64Optimize || optimizedData;

--- a/test/fixture/page.ejs
+++ b/test/fixture/page.ejs
@@ -1,0 +1,4 @@
+<body>
+    <p>An EJS file that essentially is HTML</p>
+    <p><%- process.version %></p>
+</body>


### PR DESCRIPTION
Allows user to specify which minifier to be used for unsupported extensions by passing `--js`, `--css` or `--html` argument. (#90)

Wasn't sure where and how to write a test.