### PR TITLE
Allow to fail on error option

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ Options:
   --css                       minify css
   --html                      minify html
   --auto                      auto detect format
+  --fail-on-error             exit with code 1 when minification fails
 ```
 
 The bash command below creates a code snippet saved as `hello.js`.
@@ -74,6 +75,14 @@ You can capture the output with the following:
 
 ```sh
 $ minify hello.js > hello.min.js
+```
+
+Use `--fail-on-error` to get a non-zero exit code when minification fails (useful in build scripts and CI):
+
+```sh
+$ minify broken.js --fail-on-error > broken.min.js
+$ echo $?
+1
 ```
 
 You can pass input using `cat`:

--- a/bin/minify.js
+++ b/bin/minify.js
@@ -16,12 +16,17 @@ const log = function(...args) {
 };
 
 const Argv = process.argv;
-const files = Argv.slice(2);
+const allArgs = Argv.slice(2);
+const failOnError = allArgs.includes('--fail-on-error');
+const files = allArgs.filter((f) => f !== '--fail-on-error');
 const [In] = files;
 
 log.error = (e) => {
     console.error(e);
     process.stdin.pause();
+
+    if (failOnError)
+        process.exit(1);
 };
 
 process.on('uncaughtException', (error) => {

--- a/help.json
+++ b/help.json
@@ -4,5 +4,6 @@
     "--js                       ": "minify javascript",
     "--css                      ": "minify css",
     "--html                     ": "minify html",
-    "--auto                     ": "auto detect format"
+    "--auto                     ": "auto detect format",
+    "--fail-on-error            ": "exit with code 1 when minification fails"
 }


### PR DESCRIPTION
We should make it configurable if we want an exit code non-zero upon failure of a minification or not.

Like in CI environment, we certainly don't want the broken JS to reach the production site.